### PR TITLE
Update DisplayData component to create optionlist type

### DIFF
--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -314,18 +314,23 @@ Actions
 ..     }
 
 
+.. _data_display:
 
-Data display
+Display Data
 ------------
 
-Display data, this can take in a list (`type = list`) of strings or objects containing label and value keys (`type = display`). If a list of
-objects is provided then the label and values will be displayed together (#TODO: Insert Image of both).
+A data listing component. This renders data defined in the context according to the following patterns
+dependent on the "display_type" of the component being set to "list" or "details":
+    - list: "data" should point to a list of strings, this will simply list all values provided
+    - details: "data" should point an object in the context consisting of a list of 
+               "{'label': '...', 'value': '...'}", this will list the values with stylised labels
 
-If the component is of type list then it will look like this:
+
+If the component is of type "list" then it will look like this:
 
 .. image:: static/images/data_display_strings.png
 
-If the component is of type display then it will look like this:
+If the component is of type "display" then it will look like this:
 
 .. image:: static/images/data_display_objects.png
 
@@ -359,6 +364,34 @@ Schema
 ^^^^^^
 
 .. jsonschema:: ../../src/core/schema/components/message_box.json
+
+
+OptionList
+----------
+
+A data listing selection component. This renders data defined in the context according to the patterns defined
+for the "details" variant of the :ref:`DataDisplay <data_display>` component, however the list of data
+are themselves selectable. This requires a value in the context for "data" with the structure as below:
+
+    {
+        'details': [
+                {'label': 'label1', 'value': 'value1'},
+                {'label': 'label2', 'value': 'value2'}
+            ],
+        'submitted_value': '...',
+        'submitted_key': '...',
+    }
+
+where,
+'details': a list whose elements are rendered as a label and value,
+'submitted_value': the value submitted upon selection of the option,
+'submitted_key': a value to submit is taken from the context attribute corresponding to this key.
+Note, 'submitted_value' and 'submitted_key' are mutually exclusive.
+
+Schema
+^^^^^^
+
+.. jsonschema:: ../../src/core/schema/components/option_list.json
 
 
 Toggle
@@ -402,7 +435,7 @@ Schema
 Checkbox
 --------
 
-A selectable list.
+A set of checkboxes allowing for value selection.
 
 .. note:: If two check boxes have the same value selecting either will cause both to be checked.
 

--- a/src/core/components.py
+++ b/src/core/components.py
@@ -246,15 +246,16 @@ class Button(Component):
 
 class DisplayData(Component):
     """
-    Allowed "display_type" are currently "list" and "details"
-    - "list": will list all the values so "data" will have to produces a list of strings
-    - "details": requires a list of "{'label': '...', 'value': '...'}" so "data" will have
+    Produces a display component which can list data in two different formats depending on the display_type,
+    this can be "list" or "details" and requires the following formats provided as data:
+        - "list": will list all the values provided, "data" should point to a list of strings
+        - "details": requires a list of "{'label': '...', 'value': '...'}", "data" should
                  point to such an object in the context
     """
 
     __slots__ = [
-        "display_type",
         "data",
+        "display_type"
     ]
 
     title = Translatable()
@@ -262,17 +263,20 @@ class DisplayData(Component):
 
     def __init__(self, display_type, title, data, subtitle=None, **kwargs):
         super().__init__(**kwargs)
-        self.display_type = display_type
         self.title = title
         self.data = data
         self.subtitle = subtitle
+        self.display_type = display_type
 
     def _get_default_identifier(self):
         return "_".join([self.display_type, self.title.lower().replace(" ", "_")])
 
+    def _get_type(self):
+        return self.display_type
+
     def get_base_component_dict(self):
         component = {
-            "type": self.display_type,
+            "type": self._get_type(),
             "title": self.title,
             "data": self.data,
         }
@@ -280,6 +284,34 @@ class DisplayData(Component):
             component.update(subtitle=self.subtitle)
 
         return component
+
+
+class OptionList(DisplayData):
+    """
+    This component is a selectable analogue to the DisplayData component.
+    Elements are displayed as in the "details" case of  DisplayData,
+    and upon selection a defined value is added to the context.
+    This requires data to be a list of 
+        {
+            'details': [
+                    {'label': 'label1', 'value': 'value1'},
+                    {'label': 'label2', 'value': 'value2'}
+                ],
+            'submitted_value': '...',
+            'submitted_key': '...',
+        }
+        where,
+        'details': a list whose elements are rendered as a label and
+            value,
+        'submitted_value': the value submitted upon selection of
+        the option,
+        'submitted_key': a value to submit is taken from the context
+        attribute corresponding to this key.
+        Note, 'submitted_value' and 'submitted_key' are mutually exclusive.
+    """
+
+    def _get_type(self):
+        return "optionlist"
 
 
 class Checkbox(Component):

--- a/src/core/schema/components/option_list.json
+++ b/src/core/schema/components/option_list.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://udes.io/jsonschema/workflows/components/display_data.json",
+  "title": "option_list",
+  "description": "Workflows option_list component",
+  "type": "object",
+  "properties": {
+    "type": { "type": "string", "enum": ["optionlist"] },
+    "title": { "type": "string" },
+    "data": { "$ref": "../common.json#/definitions/jsonpath" }
+  },
+  "required": ["type", "title", "data"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Optionlist type for DisplayData allows for the display to be
selected, updating the context with a defined value.

User-story: 12649
Signed-off-by: Robert Smith <robert.smith@unipart.io>