### PR TITLE
Repeat component tweaks & Fixes

### DIFF
--- a/src/core/schema/components/repeat.json
+++ b/src/core/schema/components/repeat.json
@@ -10,14 +10,19 @@
       "type": "array",
       "items": [
         {
-          "$ref": "../common/component_lookup.json#/definitions/component_lookup"
+          "type": "array",
+          "items": [
+            {
+              "$ref": "../common/component_lookup.json#/definitions/component_lookup"
+            }
+          ]
         }
       ]
     },
-    "validators": { "type": "array", "items": [{ "type": "string" }] },
-    "quantity": { "type": "integer" },
-    "quantity_path": { "$ref": "../common.json#/definitions/jsonpath" }
+    "times_to_repeat": { "type": "integer" },
+    "times_to_repeat_path": { "$ref": "../common.json#/definitions/jsonpath" },
+    "destination_path": { "$ref": "../common.json#/definitions/jsonpath" }
   },
-  "oneOf": [{ "required": ["quantity"] }, { "required": ["quantity_path"] }],
+  "oneOf": [{ "required": ["times_to_repeat"] }, { "required": ["times_to_repeat_path"] }],
   "additionalProperties": false
 }

--- a/src/core/tests/components/test_repeat.py
+++ b/src/core/tests/components/test_repeat.py
@@ -11,19 +11,11 @@ def field():
     return Input(label="Input")
 
 
-@pytest.fixture
-def component_validator():
-    return validators.is_equal(
-        validator_value=["ExpectedValue1", "ExpectedValue2", "ExpectedValue3"]
-    )
-
-
-def test_repeat(field, component_validator):
+def test_repeat(field):
     """Test repeat component creates json matching json schema"""
     repeat = Repeat(
-        components=field,
-        validators=component_validator,
-        quantity=3,
+        components=[field],
+        times_to_repeat=3,
         destination_path="$.result",
     )
     validator = get_validator_for("components/repeat")
@@ -35,7 +27,6 @@ def test_repeat_missing_required_arg(field):
     with pytest.raises(InvalidArguments):
         Repeat(
             components=field,
-            validators=component_validator,
             destination_path="$.result",
         )
 
@@ -45,8 +36,7 @@ def test_repeat_no_missing_mutually_exclusive_args(field):
     with pytest.raises(InvalidArguments):
         Repeat(
             components=field,
-            validators=component_validator,
-            quantity=3,
-            quantity_path="$.quantity",
+            times_to_repeat=3,
+            times_to_repeat_path="$.quantity",
             destination_path="$.result",
         )

--- a/src/core/workflows.py
+++ b/src/core/workflows.py
@@ -10,14 +10,26 @@ class SameIdentiferDifferentValues(Exception):
     pass
 
 
+def freeze_list(list_to_freeze):
+    return frozenset(
+        dict_to_set(value)
+        if isinstance(value, dict)
+        else freeze_list(value)
+        if isinstance(value, list)
+        else
+        value
+        for value in list_to_freeze
+    )
+
+
 def dict_to_set(d):
     return frozenset(
-        (k, dict_to_set(v))
-        if isinstance(v, dict)
-        else (k, frozenset(v))
-        if isinstance(v, list)
-        else (k, v)
-        for k, v in d.items()
+        (key, dict_to_set(value))
+        if isinstance(value, dict)
+        else (key, freeze_list(value))
+        if isinstance(value, list)
+        else (key, value)
+        for key, value in d.items()
     )
 
 


### PR DESCRIPTION
Refactor repeat component attributes, removing `validators`, and adding `destination_path`.
Rename `quantity` and `quantity_path` to `times_to_repeat` and `times_to_repeat_path`.

Also includes a fix from @unirho to address failure to use Repeat component in an actual flow, due to a hashing error in a low level function

Updated schema & test case to reflect changes