### PR TITLE
[ADD] workflows_engine: Add default in displays type

### DIFF
--- a/src/components/displays/defaults.py
+++ b/src/components/displays/defaults.py
@@ -1,10 +1,12 @@
 __all__ = (
+    "default",
     "info",
     "error",
     "warning",
     "success",
 )
 
+default = dict(identifier="default_message", message_type="default", template="This is question mark")
 info = dict(identifier="info_message", message_type="info", template="This is infomation")
 warning = dict(identifier="info_message", message_type="warning", template="This is a warning")
 error = dict(identifier="info_message", message_type="error", template="Something went wrong")

--- a/src/components/displays/displays.py
+++ b/src/components/displays/displays.py
@@ -4,12 +4,14 @@ from . import defaults
 
 
 __all__ = (
+    "default",
     "info",
     "warning",
     "error",
     "success",
 )
 
+default = func_factory(defaults.default, components.MessageBox, make_identifier)
 info = func_factory(defaults.info, components.MessageBox, make_identifier)
 warning = func_factory(defaults.warning, components.MessageBox, make_identifier)
 error = func_factory(defaults.error, components.MessageBox, make_identifier)


### PR DESCRIPTION
Story: 12655
Signed-off-by: Armand Cela <armand.cela@unipart.io>


displays.default was not in engine, while in front end Sam told me that was. 
I added it as in the story are requested displays.default, Sam has a story to change it in question mark